### PR TITLE
chore(connector): client abstractions should return paypal response

### DIFF
--- a/processor/src/clients/types/paypal.client.type.ts
+++ b/processor/src/clients/types/paypal.client.type.ts
@@ -21,6 +21,11 @@ export enum VerificationStatus {
   FAILURE = 'FAILURE',
 }
 
+export enum OrderStatus {
+  PAYER_ACTION_REQUIRED = 'PAYER_ACTION_REQUIRED',
+  COMPLETED = 'COMPLETED',
+}
+
 export type AuthenticationResponse = {
   status: number;
   accessToken: string;
@@ -66,14 +71,21 @@ export type PaypalItem = {
   description?: string;
   sku?: string;
   category?: string;
-  unit_amount: {
-    currency_code: string;
-    value: string;
-  };
+  unit_amount: Amount;
   tax?: {
     currency_code: string;
     value: string;
   };
+};
+
+export type Capture = {
+  status: string;
+  id: string;
+  amount: Amount;
+};
+
+export type Payment = {
+  captures: Capture[];
 };
 
 type PurchaseUnits = {
@@ -82,6 +94,7 @@ type PurchaseUnits = {
   invoice_id: string;
   items?: PaypalItem[];
   shipping: PaypalShipping;
+  payments?: Payment;
 };
 
 export type CreateOrderRequest = {
@@ -107,6 +120,23 @@ export type NotificationVerificationRequest = {
   transmission_time: string;
   webhook_id: string;
   webhook_event: Record<string, any>;
+};
+
+export type CaptureOrderResponse = {
+  id: string; // order ID
+  purchase_units: PurchaseUnits[];
+  status: string;
+};
+
+export type CreateOrderResponse = {
+  id: string;
+  status: string;
+};
+
+export type RefundResponse = {
+  id: string;
+  status: string;
+  amount: Amount;
 };
 
 export type NotificationVerificationResponse = {

--- a/processor/src/dtos/paypal-payment.dto.ts
+++ b/processor/src/dtos/paypal-payment.dto.ts
@@ -48,6 +48,7 @@ export const CaptureOrderRequest = Type.Object({
 export const CaptureOrderResponse = Type.Object({
   id: Type.String(),
   paymentReference: Type.String(),
+  captureStatus: Type.String(),
 });
 
 export const CaptureOrderParams = Type.Object({

--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -151,7 +151,7 @@ export abstract class AbstractPaymentService {
 
     return {
       outcome: res.outcome,
-      paymentReference: res.pspReference,
+      paymentReference: ctPayment.id,
     };
   }
 

--- a/processor/test/paypal.client.spec.ts
+++ b/processor/test/paypal.client.spec.ts
@@ -10,9 +10,8 @@ import {
 import { paypalCreateOrderRequest } from './utils/mock-paypal-request-data';
 import { setupServer } from 'msw/node';
 import { PaypalAPI } from '../src/clients/paypal.client';
-import { PaymentModificationStatus } from '../src/dtos/operations/payment-intents.dto';
 import { mockPaypalRequest } from './utils/paypal-request.mock';
-import { PaypalBasePath, PaypalUrls } from '../src/clients/types/paypal.client.type';
+import { OrderStatus, PaypalBasePath, PaypalUrls } from '../src/clients/types/paypal.client.type';
 
 describe('Paypal API', () => {
   const api = new PaypalAPI();
@@ -84,8 +83,8 @@ describe('Paypal API', () => {
       const result = await api.createOrder(paypalCreateOrderRequest);
 
       // then
-      expect(result?.outcome).toBe(PaymentModificationStatus.APPROVED);
-      expect(result?.pspReference).toBe(paypalCreateOrderOkResponse.id);
+      expect(result?.status).toBe(OrderStatus.PAYER_ACTION_REQUIRED);
+      expect(result?.id).toBe(paypalCreateOrderOkResponse.id);
     });
   });
   describe('Capture PayPal Order', () => {
@@ -102,8 +101,8 @@ describe('Paypal API', () => {
       const result = await api.captureOrder(orderId);
 
       // then
-      expect(result.outcome).toBe(PaymentModificationStatus.APPROVED);
-      expect(result.pspReference).toBe(paypalCaptureOrderOkResponse.purchase_units[0].payments.captures[0].id);
+      expect(result.status).toBe(OrderStatus.COMPLETED);
+      expect(result.id).toBe(paypalCaptureOrderOkResponse.id);
     });
 
     it('should return an error when PayPal return a not found order', async () => {
@@ -141,8 +140,8 @@ describe('Paypal API', () => {
       });
 
       // then
-      expect(result.outcome).toBe(PaymentModificationStatus.APPROVED);
-      expect(result.pspReference).toBe(paypalRefundOkResponse.id);
+      expect(result.status).toBe(OrderStatus.COMPLETED);
+      expect(result.id).toBe(paypalRefundOkResponse.id);
     });
 
     it('should perform a full refund on the captured order', async () => {
@@ -157,8 +156,8 @@ describe('Paypal API', () => {
       const result = await api.refundFullPayment(captureId);
 
       // then
-      expect(result.outcome).toBe(PaymentModificationStatus.APPROVED);
-      expect(result.pspReference).toBe(paypalRefundOkResponse.id);
+      expect(result.status).toBe(OrderStatus.COMPLETED);
+      expect(result.id).toBe(paypalRefundOkResponse.id);
     });
 
     it('should return an error when PayPal return a not found error', async () => {


### PR DESCRIPTION
The Client abstractions should return the exact paypal response. This is particularly important in situations where we need some information on the service level, to determine the status of a payment operation.

This PR would move the conversion of responses, up into the service layer.

For the modification endpoints, return the payment id in the `paymentReference` field