### PR TITLE
Fix style and text of Paypal button

### DIFF
--- a/enabler/src/components/payment-methods/paypal/paypal.ts
+++ b/enabler/src/components/payment-methods/paypal/paypal.ts
@@ -38,6 +38,10 @@ export class PaypalComponent extends DefaultPaypalComponent {
 
   init() {
     this.component = this.baseOptions.sdk.Buttons({
+      style: {
+        height: 40,
+        label: "buynow",
+      },
       onClick: async (_, actions) => {
         if (!this.componentOptions.onClick()) {
           return actions.reject();


### PR DESCRIPTION
Before:

<img width="542" alt="image" src="https://github.com/commercetools/connect-payment-integration-paypal/assets/100839194/84e88618-da86-40ee-a607-68baa59e6a16">


After:

<img width="591" alt="image" src="https://github.com/commercetools/connect-payment-integration-paypal/assets/100839194/3f1f987a-2db0-40a5-ba46-840c42afa5bc">


