### PR TITLE
fix(paypal): set funding source

### DIFF
--- a/enabler/src/components/payment-methods/paypal/paypal.ts
+++ b/enabler/src/components/payment-methods/paypal/paypal.ts
@@ -42,6 +42,7 @@ export class PaypalComponent extends DefaultPaypalComponent {
         height: 40,
         label: "buynow",
       },
+      fundingSource: 'paypal',
       onClick: async (_, actions) => {
         if (!this.componentOptions.onClick()) {
           return actions.reject();


### PR DESCRIPTION
This configures the `fundingSource` to avoid rendering multiple buttons in our PayPal enabler.

e.g. 
| before | after |
|--------|--------|
| ![image](https://github.com/commercetools/connect-payment-integration-paypal/assets/17336834/4967d0a3-0889-456d-8d42-3151c51ee689) |  ![image](https://github.com/commercetools/connect-payment-integration-paypal/assets/17336834/a9d033a5-56b4-4b50-95d1-a5cfa84b979b) | 
