### PR TITLE
feat(payment-intents): Support linking refund requests to existing transactions

### DIFF
--- a/processor/src/dtos/operations/payment-intents.dto.ts
+++ b/processor/src/dtos/operations/payment-intents.dto.ts
@@ -22,6 +22,7 @@ export const ActionRefundPaymentSchema = Type.Composite([
   Type.Object({
     amount: AmountSchema,
     merchantReference: Type.Optional(Type.String()),
+    transactionId: Type.Optional(Type.String()),
   }),
 ]);
 

--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -148,6 +148,7 @@ export abstract class AbstractPaymentService {
           amount: request.amount,
           payment: ctPayment,
           merchantReference: request.merchantReference,
+          transactionId: request.transactionId,
         });
       }
       case 'reversePayment': {

--- a/processor/src/services/types/operation.type.ts
+++ b/processor/src/services/types/operation.type.ts
@@ -22,6 +22,7 @@ export type RefundPaymentRequest = {
   amount: AmountSchemaDTO;
   payment: Payment;
   merchantReference?: string;
+  transactionId?: string;
 };
 
 export type ReversePaymentRequest = {


### PR DESCRIPTION
Support linking refund requests to existing transactions. This is helpful when in the refund requests we have to include the capture PSP reference.

https://commercetools.atlassian.net/browse/SCC-3413